### PR TITLE
Added feature: teleport to entity when selecting it from the menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Vendor directory for dependencies
 dependencies/
+bin/
 
 # Dependency versions lockfile
 pawn.lock


### PR DESCRIPTION
Added feature: teleport to entity when selecting it from the menu
Fixed bug where the guide line wasn't drawn properly ( pev_origin doesn't work on brush entities)
Fixed bug where you add the entity to the undo list before actually removing it
Removed redundant code